### PR TITLE
remove test as and test space

### DIFF
--- a/allocations/asn.md
+++ b/allocations/asn.md
@@ -15,6 +15,5 @@ Please add your ASN in lexicographical order.
 | 64498 | [darkdrgn2k](https://github.com/darkdrgn2k)|
 | 64499 | [brannondorsey](https://github.com/brannondorsey)|
 | 64507 | [Bandura Communications](https://byeob.de/)|
-| 64511 | TEST ASN      |
 
 This range may change at any time if it is found to conflict with another range or be unusable for any reason.

--- a/allocations/ipv4.md
+++ b/allocations/ipv4.md
@@ -15,6 +15,5 @@ Please add your allocation in lexicographical order.
 | 172.24.2.0/24   | 172.24.2.0 - 172.24.2.255     | [darkdrgn2k](https://github.com/darkdrgn2k)|
 | 172.24.3.0/24   | 172.24.3.0 - 172.24.3.255     | [brannondorsey](https://github.com/brannondorsey)|
 | 172.24.7.0/24   | 172.24.7.0 - 172.24.7.255     | [Bandura Communications](https://byeob.de/)|
-| 172.24.255.0/24 | 172.24.255.0 - 172.24.255.255 | TEST RANGE    |
 
 These ranges may be changed at any time if they are found to conflict with another range or be unusable for any reason.

--- a/allocations/ipv6.md
+++ b/allocations/ipv6.md
@@ -15,6 +15,5 @@ Please add your allocation in lexicographical order.
 | 2001:db8:dead:beef:cafe:babe:0::/112    | 2001:db8:dead:beef:cafe:babe:0:0 - 2001:db8:dead:beef:cafe:babe:0:ffff       | [mikenabhan](https://github.com/mikenabhan)|
 | 2001:db8:dead:beef:cafe:be11:0::/112    | 2001:db8:dead:beef:cafe:be11:0:0 - 2001:db8:dead:beef:cafe:be11:0:ffff       | [darkdrgn2k](https://github.com/darkdrgn2k)|
 | 2001:db8:dead:beef::/112                | 2001:db8:dead:beef:0:0:0:0 - 2001:db8:dead:beef:0:0:0:ffff                   | [brannondorsey](https://github.com/brannondorsey)|
-| 2001:db8:dead:beef:ffff:ffff:ffff::/112 | 2001:db8:dead:beef:ffff:ffff:ffff:0 - 2001:db8:dead:beef:ffff:ffff:ffff:ffff | TEST RANGE    |
 
 These ranges may be changed at any time if they are found to conflict with another range or be unusable for any reason.


### PR DESCRIPTION
It is impossible to build ROA rules if there is no common denominator like an ID between range and IP. With the others you can take the "User" as ID, but not with the Test Range. Therefore I would remove this or alternatively assign an ID to each entry.