### PR TITLE
remove ASN64511 and leave router.city

### DIFF
--- a/allocations/asn.md
+++ b/allocations/asn.md
@@ -14,6 +14,5 @@ Please add your ASN in lexicographical order.
 | 64497 | [mikenabhan](https://github.com/mikenabhan)|
 | 64498 | [darkdrgn2k](https://github.com/darkdrgn2k)|
 | 64499 | [brannondorsey](https://github.com/brannondorsey)|
-| 64507 | [Bandura Communications](https://byeob.de/)|
 
 This range may change at any time if it is found to conflict with another range or be unusable for any reason.

--- a/allocations/asn.md
+++ b/allocations/asn.md
@@ -2,7 +2,7 @@
 
 Each organization on the router.city network with control of an address block will need a unique Autonomous System Number (ASN) to identify the organization's network.
 
-AS numbers will be assigned from the `64496 - 64511` range, which is reserved space for documentation and source code examples.
+AS numbers will be assigned from the `64496 - 64510` range, which is reserved space for documentation and source code examples.
 
 Please add your ASN in lexicographical order.
 

--- a/allocations/ipv4.md
+++ b/allocations/ipv4.md
@@ -14,6 +14,5 @@ Please add your allocation in lexicographical order.
 | 172.24.1.0/24   | 172.24.1.0 - 172.24.1.255     | [mikenabhan](https://github.com/mikenabhan)|
 | 172.24.2.0/24   | 172.24.2.0 - 172.24.2.255     | [darkdrgn2k](https://github.com/darkdrgn2k)|
 | 172.24.3.0/24   | 172.24.3.0 - 172.24.3.255     | [brannondorsey](https://github.com/brannondorsey)|
-| 172.24.7.0/24   | 172.24.7.0 - 172.24.7.255     | [Bandura Communications](https://byeob.de/)|
 
 These ranges may be changed at any time if they are found to conflict with another range or be unusable for any reason.

--- a/allocations/ipv6.md
+++ b/allocations/ipv6.md
@@ -10,7 +10,6 @@ Please add your allocation in lexicographical order.
 
 | CIDR                                    | Range                                                                        | User          |
 | --------------------------------------- | ---------------------------------------------------------------------------- | ------------- |
-| 2001:db8:dead:beef:4cbe::/80            | 2001:0db8:dead:beef:4cbe:0:0:0 - 2001:0db8:dead:beef:4cbe:ffff:ffff:ffff     | [Bandura Communications](https://byeob.de/)|
 | 2001:db8:dead:beef:cafe:f00d:0::/112    | 2001:db8:dead:beef:cafe:f00d:0:0 - 2001:db8:dead:beef:cafe:f00d:0:ffff       | [Famicoman](https://github.com/Famicoman)|
 | 2001:db8:dead:beef:cafe:babe:0::/112    | 2001:db8:dead:beef:cafe:babe:0:0 - 2001:db8:dead:beef:cafe:babe:0:ffff       | [mikenabhan](https://github.com/mikenabhan)|
 | 2001:db8:dead:beef:cafe:be11:0::/112    | 2001:db8:dead:beef:cafe:be11:0:0 - 2001:db8:dead:beef:cafe:be11:0:ffff       | [darkdrgn2k](https://github.com/darkdrgn2k)|


### PR DESCRIPTION
This AS number is already used by dn42 to distribute routing information. See https://wiki.dn42/howto/Bird-communities.